### PR TITLE
ArrowButton sizeThatFits

### DIFF
--- a/Sources/ArrowButton.swift
+++ b/Sources/ArrowButton.swift
@@ -28,8 +28,8 @@ open class ArrowButton: UIButton {
   }
 
   open override func sizeThatFits(_ size: CGSize) -> CGSize {
-    return CGSize(width: label.frame.size.width + arrowSize*2 + padding,
-                  height: label.frame.size.height)
+    return CGSize(width: label.intrinsicContentSize.width + arrowSize * 2 + padding,
+                  height: label.intrinsicContentSize.height)
   }
 
   // MARK: - Views


### PR DESCRIPTION
It will wait for next UI update.
So, if you get frame width of label, you will get CGRectZero.

Before fix:
![simulator screen shot - iphone x - 2018-05-18 at 02 18 37](https://user-images.githubusercontent.com/15200940/40205129-5656075a-5a44-11e8-96d5-e1d598822f34.png)

After fix:
![simulator screen shot - iphone x - 2018-05-18 at 02 19 42](https://user-images.githubusercontent.com/15200940/40205146-63f1c66a-5a44-11e8-945a-a3ce770182d3.png)

